### PR TITLE
Added cookie name to getCookieConsentValue

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -14,7 +14,7 @@ import ReactGA from "react-ga4";
 
 export default function App({ Component, pageProps }: AppProps){
   useEffect(() => {
-    const isConsent = getCookieConsentValue();
+    const isConsent = getCookieConsentValue("mrwebersYummyCookie");
     if (isConsent === "true") {
       handleAcceptCookie();
     }


### PR DESCRIPTION
The issue was that getCookieConsentValue without arguments tried to fetch a default value, hence why the return value was undefined because the cookie name was custom