### PR TITLE
Added id property to Reel Detail component

### DIFF
--- a/components/Reel.tsx
+++ b/components/Reel.tsx
@@ -78,9 +78,10 @@ interface Project {
 
 interface props {
   projects: Project[];
+  id: string;
 }
 
-export default function Reel({ projects }: props) {
+export default function Reel({ projects, id }: props) {
   /*
     This ref references the grid container
   */
@@ -128,7 +129,7 @@ export default function Reel({ projects }: props) {
       setOpen(true);
       setFadeIn(true);
       setTimeout(function () {
-        document.getElementById('bigscreen')?.scrollIntoView({
+        document.getElementById(`bigscreen_${id}`)?.scrollIntoView({
           behavior: 'smooth',
           block: 'start',
           inline: 'center',
@@ -148,7 +149,7 @@ export default function Reel({ projects }: props) {
     // if the text box is visible but the newly clicked element is on a new row, it moves the text box accordingly and scrolls it into view
     if (open && indx != index) {
       setTimeout(function () {
-        document.getElementById('bigscreen')?.scrollIntoView({
+        document.getElementById(`bigscreen_${id}`)?.scrollIntoView({
           behavior: 'smooth',
           block: 'start',
           inline: 'center',
@@ -195,6 +196,7 @@ export default function Reel({ projects }: props) {
           index={indx}
           project={projects[indx]}
           grid={grid}
+          id={id}
         />
       ) : null}
     </div>

--- a/components/ReelDetail.tsx
+++ b/components/ReelDetail.tsx
@@ -80,9 +80,10 @@ interface Props {
   index: number;
   project: Project;
   grid: number[];
+  id: string;
 }
 
-export default function ReelDetail({ fadeIn, index, project, grid }: Props) {
+export default function ReelDetail({ fadeIn, index, project, grid, id }: Props) {
   const gridCol: number = grid[0];
   const gridRow: number = grid[1]; // This is not really used but fun to know anyways
 
@@ -101,7 +102,7 @@ export default function ReelDetail({ fadeIn, index, project, grid }: Props) {
   return (
     <div
       className={`${s.bigScreen} ${fadeIn ? s.fadeIn : s.fadeOut}`}
-      id="bigscreen"
+      id={`bigscreen_${id}`}
       style={{
         gridRowStart: rowPosition + 1,
         gridRowEnd: rowPosition + 2,

--- a/pages/portfolio.tsx
+++ b/pages/portfolio.tsx
@@ -132,11 +132,11 @@ export default function Portfolio({projects, demos, info, taglines}:Props) {
         <div className="description" dangerouslySetInnerHTML={{__html: info[0].intro}}></div>
         <h2>Webseiten</h2>
         <div className="description" dangerouslySetInnerHTML={{__html: info[0].projects}}></div>
-        <DynamicReel projects={projects} />
+        <DynamicReel projects={projects} id={`live`}/>
         <div className="divider"></div>
         <h2>Demos & Beispiele</h2>
         <div className="description" dangerouslySetInnerHTML={{__html: info[0].demos}}></div>
-        <DynamicReel projects={demos} />
+        <DynamicReel projects={demos} id={`demo`}/>
       </section>
     </main>
     </>


### PR DESCRIPTION
This is because the Reel Detail container had a DOM id, and more than one Reel component caused wrong scrollIntoView behavior. Now, each Reel Detail gets a unique id by which scrollIntoView can identify the correct target